### PR TITLE
Fix vertex/edge string format

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,16 @@ $ ./nebula-console -addr <ip> -port <port> -u <username> -p <password>
     [-t 120] [-e "nGQL_statement" | -f filename.nGQL]
 ```
 
-| Option       | Description                                                                                                                                                                   |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-h`           | Shows the help menu.                                                                                                                                                           |
-| `-addr`        | Sets the IP/HOST address of the graphd service. The default address is 127.0.0.1.                                                                                                   |
-| `-port`        | Sets the port number of the graphd service.                                                                                                   |
-| `-u/-user`     | Sets the username of your Nebula Graph account.                                                                                                |
-| `-pw/-password`| Sets the password of your Nebula Graph account.                                                                             |
-| `-t/-timeout`  | Sets an integer-type timeout threshold for the connection. The unit is second. The default value is 120.                                                                        |
-| `-e/-eval`     | Sets a string-type nGQL statement. The nGQL statement is executed once the connection succeeds. The connection stops after the result is returned.             |
-| `-f/-file`     | Sets the path of an nGQL file. The nGQL statements in the file are executed once the connection succeeds. You'll get the return messages and the connection stops then. |
+| Option         | Description                                                                                                                                                                   |
+| ------------   | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-h`           | Shows the help menu.                                                                                                                                                          |
+| `-addr`        | Sets the IP/HOST address of the graphd service. The default address is 127.0.0.1.                                                                                             |
+| `-P/port`      | Sets the port number of the graphd service.                                                                                                                                   |
+| `-u/-user`     | Sets the username of your Nebula Graph account.                                                                                                                               |
+| `-p/-password` | Sets the password of your Nebula Graph account.                                                                                                                               |
+| `-t/-timeout`  | Sets an integer-type timeout threshold for the connection. The unit is second. The default value is 120.                                                                      |
+| `-e/-eval`     | Sets a string-type nGQL statement. The nGQL statement is executed once the connection succeeds. The connection stops after the result is returned.                            |
+| `-f/-file`     | Sets the path of an nGQL file. The nGQL statements in the file are executed once the connection succeeds. You'll get the return messages and the connection stops then.       |
 
 Check options for `./nebula-console -h`, try `./nebula-console` in interactive mode directly.
 And try `./nebula-console -e 'show hosts'` for the direct script mode.
@@ -175,5 +175,4 @@ Key Binding                                     | Description
 ## TODO
 
 - CI/CD
-- package to RPM/DEB/DOCKER
 - batch process to reduce memory consumption and speed up IO

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ go version
 Use Git to clone the source code of Nebula Graph Console to your host.
 
 ```bash
-$ git clone git@github.com:vesoft-inc/nebula-console.git
+$ git clone https://github.com/vesoft-inc/nebula-console
 ```
 
 Run the following command to build Nebula Graph Console.

--- a/main.go
+++ b/main.go
@@ -255,7 +255,7 @@ func loop(client *ngdb.GraphClient, c cli.Cli, isPlayingData bool) error {
 }
 
 var address *string = flag.String("addr", "127.0.0.1", "The Nebula Graph IP/HOST address")
-var port *int = flag.Int("port", -1, "The Nebula Graph Port")
+var port *int = flag.Int("P", -1, "The Nebula Graph Port")
 var username *string = flag.String("u", "", "The Nebula Graph login user name")
 var password *string = flag.String("p", "", "The Nebula Graph login password")
 var timeout *int = flag.Int("t", 120, "The Nebula Graph client connection timeout in seconds")
@@ -264,6 +264,7 @@ var file *string = flag.String("f", "", "The nGQL script file name")
 
 func init() {
 	flag.StringVar(address, "address", "127.0.0.1", "The Nebula Graph IP/HOST address")
+	flag.IntVar(port, "port", -1, "The Nebula Graph Port")
 	flag.StringVar(username, "user", "", "The Nebula Graph login user name")
 	flag.StringVar(password, "password", "", "The Nebula Graph login password")
 	flag.IntVar(timeout, "timeout", 120, "The Nebula Graph client connection timeout in seconds")

--- a/printer/dataset_printer.go
+++ b/printer/dataset_printer.go
@@ -117,7 +117,7 @@ func valueToString(value *nebula.Value) string {
 			tagString := fmt.Sprintf(" :%s{%s}", tagName, strings.Join(props, ", "))
 			tags = append(tags, tagString)
 		}
-		buffer.WriteString(strings.Join(tags, ","))
+		buffer.WriteString(strings.Join(tags, " "))
 		buffer.WriteString(`)`)
 		return buffer.String()
 	} else if value.IsSetEVal() { // Edge

--- a/printer/dataset_printer.go
+++ b/printer/dataset_printer.go
@@ -101,11 +101,12 @@ func valueToString(value *nebula.Value) string {
 			datetime.GetHour(), datetime.GetMinute(), datetime.GetSec(), datetime.GetMicrosec())
 		return str
 	} else if value.IsSetVVal() { // Vertex
+		// ("VertexID" :tag1{k0:v0,k1:v1}:tag2{k2:v2})
 		var buffer bytes.Buffer
 		vertex := value.GetVVal()
 		buffer.WriteString(`("`)
 		buffer.WriteString(string(vertex.GetVid()))
-		buffer.WriteString(`")`)
+		buffer.WriteString(`"`)
 		var tags []string
 		for _, tag := range vertex.GetTags() {
 			var props []string
@@ -117,9 +118,10 @@ func valueToString(value *nebula.Value) string {
 			tags = append(tags, tagString)
 		}
 		buffer.WriteString(strings.Join(tags, ","))
+		buffer.WriteString(`)`)
 		return buffer.String()
 	} else if value.IsSetEVal() { // Edge
-		// (src)-[edge]->(dst)@ranking {props}
+		// (src)-[:edge@ranking{props}]->(dst)
 		edge := value.GetEVal()
 		var buffer bytes.Buffer
 		src := string(edge.GetSrc())
@@ -132,11 +134,11 @@ func valueToString(value *nebula.Value) string {
 			props = append(props, fmt.Sprintf("%s: %s", k, valueToString(v)))
 		}
 		propsString := strings.Join(props, ", ")
-		buffer.WriteString(fmt.Sprintf(`("%s")-[%s]->("%s")@%d{%s}`,
-			src, edge.GetName(), dst, edge.GetRanking(), propsString))
+		buffer.WriteString(fmt.Sprintf(`("%s")-[:%s@%d{%s}]->("%s")`,
+			src, edge.GetName(), edge.GetRanking(), propsString, dst))
 		return buffer.String()
 	} else if value.IsSetPVal() { // Path
-		// (src)-[TypeName@ranking]->(dst)-[TypeName@ranking]->(dst) ...
+		// (src)-[:TypeName@ranking]->(dst)-[:TypeName@ranking]->(dst) ...
 		var buffer bytes.Buffer
 		p := value.GetPVal()
 		srcVid := string(p.GetSrc().GetVid())
@@ -144,9 +146,9 @@ func valueToString(value *nebula.Value) string {
 		for _, step := range p.GetSteps() {
 			dstVid := string(step.GetDst().GetVid())
 			if step.GetType() > 0 {
-				buffer.WriteString(fmt.Sprintf("-[%s@%d]->(%q)", step.GetName(), step.GetRanking(), dstVid))
+				buffer.WriteString(fmt.Sprintf("-[:%s@%d]->(%q)", step.GetName(), step.GetRanking(), dstVid))
 			} else {
-				buffer.WriteString(fmt.Sprintf("<-[%s@%d]-(%q)", step.GetName(), step.GetRanking(), dstVid))
+				buffer.WriteString(fmt.Sprintf("<-[:%s@%d]-(%q)", step.GetName(), step.GetRanking(), dstVid))
 			}
 		}
 		return buffer.String()

--- a/printer/dataset_printer.go
+++ b/printer/dataset_printer.go
@@ -117,7 +117,7 @@ func valueToString(value *nebula.Value) string {
 			tagString := fmt.Sprintf(" :%s{%s}", tagName, strings.Join(props, ", "))
 			tags = append(tags, tagString)
 		}
-		buffer.WriteString(strings.Join(tags, " "))
+		buffer.WriteString(strings.Join(tags, ""))
 		buffer.WriteString(`)`)
 		return buffer.String()
 	} else if value.IsSetEVal() { // Edge


### PR DESCRIPTION
@randomJoe211 Need to update examples in our document

https://docs.nebula-graph.io/2.0/3.ngql-guide/7.general-query-statements/2.match/

## format reference:

https://github.com/opencypher/openCypher/tree/master/tck#format-of-the-expected-results

### Vertex

```text
("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})
```

### Edge

```text
("Tim Duncan")-[:serve@0{end_year: 2016, start_year: 1997}]->("Spurs")
```

### Path

```text
("Tim Duncan")-[:serve@0]->("Spurs")<-[:serve@0]-("Tony Parker")
```