### PR TITLE
Delete seperator line between rows

### DIFF
--- a/printer/writer_config.go
+++ b/printer/writer_config.go
@@ -13,5 +13,5 @@ import (
 
 func configTableWriter(writer *table.Writer) {
 	(*writer).Style().Format.Header = text.FormatDefault
-	(*writer).Style().Options.SeparateRows = true
+	(*writer).Style().Options.SeparateRows = false
 }


### PR DESCRIPTION
The current style is consistent with relational databases such as mysql, and this is also more convenient for us to generate tck test result

```
Execution succeeded (time spent 783/1264 us)

Wed, 29 Sep 2021 20:48:07 CST

(root@nebula) [nba]> show tags;
+------------+
| Name       |
+------------+
| "bachelor" |
| "player"   |
| "team"     |
+------------+
Got 3 rows (time spent 577/930 us)

Wed, 29 Sep 2021 20:48:09 CST

(root@nebula) [nba]> go from "Tim Duncan" over like yield like._dst, like._dst
+-----------------+-----------------+
| like._dst       | like._dst       |
+-----------------+-----------------+
| "Manu Ginobili" | "Manu Ginobili" |
| "Tony Parker"   | "Tony Parker"   |
+-----------------+-----------------+
Got 2 rows (time spent 1844/2377 us)

Wed, 29 Sep 2021 20:49:56 CST
```