### PR TITLE
Restore separate lines for plan description table

### DIFF
--- a/printer/dataset_printer.go
+++ b/printer/dataset_printer.go
@@ -23,7 +23,7 @@ type DataSetPrinter struct {
 
 func NewDataSetPrinter() DataSetPrinter {
 	writer := table.NewWriter()
-	configTableWriter(&writer)
+	configTableWriter(&writer, false)
 	return DataSetPrinter{
 		writer: writer,
 	}

--- a/printer/plan_desc_printer.go
+++ b/printer/plan_desc_printer.go
@@ -32,7 +32,7 @@ type PlanDescPrinter struct {
 
 func NewPlanDescPrinter() PlanDescPrinter {
 	writer := table.NewWriter()
-	configTableWriter(&writer)
+	configTableWriter(&writer, true)
 	return PlanDescPrinter{
 		writer: writer,
 	}

--- a/printer/writer_config.go
+++ b/printer/writer_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 )
 
-func configTableWriter(writer *table.Writer) {
+func configTableWriter(writer *table.Writer, separateRows bool) {
 	(*writer).Style().Format.Header = text.FormatDefault
-	(*writer).Style().Options.SeparateRows = false
+	(*writer).Style().Options.SeparateRows = separateRows
 }


### PR DESCRIPTION
It's better to separate rows in plan desc table for more clearly differentiate plan nodes. 

Fix the error introduced in #134 