### PR TITLE
pretty printing the time of response

### DIFF
--- a/main.go
+++ b/main.go
@@ -293,13 +293,13 @@ func printResultSet(res *nebulago.ResultSet, startTime time.Time) (duration time
 		numRows := res.GetRowSize()
 		duration = time.Since(startTime)
 		if numRows > 0 {
-			fmt.Printf("Got %d rows (time spent %d/%d us)\n", numRows, res.GetLatency(), duration/1000)
+			fmt.Printf("Got %d rows (time spent %v/%v)\n", numRows, time.Duration(res.GetLatency()*1000), duration)
 		} else {
-			fmt.Printf("Empty set (time spent %d/%d us)\n", res.GetLatency(), duration/1000)
+			fmt.Printf("Empty set (time spent %v/%v)\n", time.Duration(res.GetLatency()*1000), duration)
 		}
 	} else {
 		duration = time.Since(startTime)
-		fmt.Printf("Execution succeeded (time spent %d/%d us)\n", res.GetLatency(), duration/1000)
+		fmt.Printf("Execution succeeded (time spent %v/%v)\n", time.Duration(res.GetLatency()*1000), duration)
 	}
 
 	if res.IsPartialSucceed() {


### PR DESCRIPTION
Before:
```
Got 1 rows (time spent 1088/13207 us)
Got 1 rows (time spent 12415178/12411742 us)
```

After:
```
Got 1 rows (time spent 26.378ms/27.311133ms)
Got 1 rows (time spent 12.407807s/12.404136118s)
```