### PR TITLE
feat: add arm64 build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,14 +10,17 @@ jobs:
     name: build docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Log into registry
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: vesoft/nebula-console
-          tags: nightly, v3-nightly
-          add_git_labels: true
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: vesoft/nebula-console/nightly, vesoft/nebula-console/v3-nightly


### PR DESCRIPTION
update docker/build-push-action to v3
add QEMU and Buildx actions for multi-platform support
align steps with the example from official docs

according to the [docs](https://github.com/docker/build-push-action#git-context), the action uses Git context so there's no need to use the checkout action beforehand

close #174 