### PR TITLE
Extend expression of :dot with some aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,18 @@ nebula> :csv a.csv
 
 ```nGQL
 nebula> :dot a.dot
-nebula> PROFILE FORMAT="dot" GO FROM "Tony Parker" OVER like;
+nebula> PROFILE FORMAT="dot" GO FROM "player102" OVER serve YIELD dst(edge);
 ```
 You can paste the content in the dot file to `https://dreampuf.github.io/GraphvizOnline/` to show the execution plan.
+
+* Export the execution plan in ASCII Table to a file when profiling a statement :
+
+```nGQL
+nebula> :profile profile.log
+nebula> PROFILE GO FROM "player102" OVER serve YIELD dst(edge);
+nebula> :explain explain.log
+nebula> EXPLAIN GO FROM "player102" OVER serve YIELD dst(edge);
+```
 
 * Load the demonstration `basketballplayer` dataset:
 

--- a/main.go
+++ b/main.go
@@ -29,15 +29,15 @@ import (
 
 // Console side commands
 const (
-	Unknown   = -1
-	Quit      = 0
-	PlayData  = 1
-	Sleep     = 2
-	ExportCsv = 3
-	ExportDot = 4
-	Repeat    = 5
-	Param     = 6
-	Params    = 7
+	Unknown             = -1
+	Quit                = 0
+	PlayData            = 1
+	Sleep               = 2
+	ExportCsv           = 3
+	ExportExecutionPlan = 4
+	Repeat              = 5
+	Param               = 6
+	Params              = 7
 )
 
 type ParameterMap map[string]interface{}
@@ -218,9 +218,9 @@ func isConsoleCmd(cmd string) (isLocal bool, localCmd int, args []string) {
 			localCmd = ExportCsv
 			args = []string{words[1]}
 		}
-	case "dot":
+	case "dot", "profile", "explain":
 		{
-			localCmd = ExportDot
+			localCmd = ExportExecutionPlan
 			args = []string{words[1]}
 		}
 	case "param":
@@ -241,8 +241,8 @@ func executeConsoleCmd(c cli.Cli, cmd int, args []string) {
 	switch cmd {
 	case ExportCsv:
 		dataSetPrinter.ExportCsv(args[0])
-	case ExportDot:
-		planDescPrinter.ExportDot(args[0])
+	case ExportExecutionPlan:
+		planDescPrinter.ExportExecutionPlan(args[0])
 	case PlayData:
 		newSpace, err := playData(args[0])
 		if err != nil {

--- a/printer/plan_desc_printer.go
+++ b/printer/plan_desc_printer.go
@@ -37,7 +37,7 @@ func NewPlanDescPrinter() PlanDescPrinter {
 	}
 }
 
-func (p *PlanDescPrinter) ExportDot(filename string) {
+func (p *PlanDescPrinter) ExportExecutionPlan(filename string) {
 	fd, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
 		fmt.Printf("Open or Create file %s failed, %s", filename, err.Error())


### PR DESCRIPTION
Commands named explain and profile are more reasonable as the formats other than dot is handled, too, which is actually needed(quite a lot), too

Then we could suggest this approach in corresponding docs to make user to share log profile ascii tables easier.

Previously they have to do a screen capture or use :CSV, where neither is elegant.

---------

其实 `:dot` 本身对非 dot 的场景也支持，但是 dot 这个名字容易让人忽视它的作用，大多数人不知道 `:dot` 就可以把超级长、宽的 profile/explain 输出到文件，所以他们都要么截图，要么输出 `:csv`（csv 结果太难看了），我甚至遇到一些同学总是给我 JSON 输出（可能是 studio 的表格输出），因为执行计划太长了，超出了他们的 cmd.exe 历史长度（也不方便复制），之前只考虑用 `-eval` 去操作，我也是最近才知道 `:dot` 是正道，但是被 `:dot` 的名字迷惑了不知道其实支持 ascii table 的情况。

现在不如给 :dot 增加两个 `:profile` 和 `:explain` 的 alias，然后在文档中值得提及的地方（或者论坛中的guide里）引导同学们用 `:profile profile.log` 去收集文本的执行计划。

- [ ] 在论坛增加 guide @wey-gu 
- [ ] 更新必要的文档章节 @wey-gu 