### PR TITLE
Docker Push with arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           tags: vesoft/nebula-console/nightly, vesoft/nebula-console/v3-nightly
+          push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,8 +10,6 @@ jobs:
     name: build docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Log into registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,6 @@ jobs:
     name: build docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Docker meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64,linux/arm64
-          tags: vesoft/nebula-console/v3, vesoft/nebula-console/latest
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,37 @@ jobs:
     name: build docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            vesoft/nebula-console
+          tags: |
+            # git tag & latest coverred
+            type=ref,event=tag
+            # git branch
+            type=ref,event=branch
+            # v3
+            type=semver,pattern=v{{version}}
+            # v3.0
+            type=semver,pattern=v{{major}}.{{minor}}
+            # v3.0.0
+            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+      - name: Log into registry
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: vesoft/nebula-console
-          tags: v3,latest
-          tag_with_ref: true
-          add_git_labels: true
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+          tags: vesoft/nebula-console/v3, vesoft/nebula-console/latest
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- enable nightly docker build push
- us v3 and buildx for docker build in release with arm64

close #188

This also fix the nebula-docker-compose console container error in Apple Chip macOS and Respberry Pi
- https://community-chat.nebula-graph.io/t/5079732/running-11-11-network-v3-3-nebula-net-created-0-0s-container
- https://community-chat.nebula-graph.io/t/5079734/https-github-com-vesoft-inc-nebula-docker-compose