### PR TITLE
fix docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,8 @@ jobs:
     name: build docker image
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU        
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Log into registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
     name: build docker image
     runs-on: ubuntu-latest
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Docker meta


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
#188

#### Description:

qemu is needed for buildx to build docker image for arm64

```log
------
Dockerfile:5
--------------------
   3 |     COPY . /usr/src
   4 |     
   5 | >>> RUN cd /usr/src && apk add --no-cache git make && make
   6 |     
   7 |     FROM alpine
--------------------
ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c cd /usr/src && apk add --no-cache git make && make" did not complete successfully: exit code: 2
Error: buildx failed with: ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c cd /usr/src && apk add --no-cache git make && make" did not complete successfully: exit code: 2

```

