### PR TITLE
make: parse git hash from github env first

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
     name: build docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Set up QEMU        
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ name ?= nebula-console
 
 # build with verison infos
 buildDate = $(shell TZ=UTC date +%FT%T%z)
-gitCommit = $(shell git log --pretty=format:'%h' -1)
+gitCommit = ${GITHUB_SHA::7}
+gitCommit ?= $(shell git log --pretty=format:'%h' -1)
 
 ldflags="-w -X main.gitTag=${gitTag} -X main.buildDate=${buildDate} -X main.gitCommit=${gitCommit}"
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number:  #188


#### Description:

To enable make being run in buildx, we cannot assume `git log` could fetch the hash, instead, it could be fetched from the env variable instead.

The nightly build phase was tested in local [act](https://github.com/nektos/act) env in https://gist.github.com/wey-gu/c57a2f6eb4d3eaab9208feda42fa8b48