### PR TITLE
chore: UX improvemnts on omit args & error handling

### DIFF
--- a/cli/icli.go
+++ b/cli/icli.go
@@ -27,7 +27,7 @@ func NewiCli(historyFile, user string, enableGoPrompt bool) Cli {
 
 	f, err := os.OpenFile(historyFile, os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
-		log.Panicf("Open or create history file %s failed, %s", historyFile, err.Error())
+		log.Fatalf("Open or create history file %s failed, %s", historyFile, err.Error())
 	}
 	defer f.Close()
 	t.ReadHistory(f)
@@ -112,7 +112,7 @@ func (l *iCli) Close() {
 	defer l.terminal.Close()
 	f, err := os.OpenFile(l.status.historyFile, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0666)
 	if err != nil {
-		log.Panicf("Open or create history file %s failed, %s", l.status.historyFile, err.Error())
+		log.Fatalf("Open or create history file %s failed, %s", l.status.historyFile, err.Error())
 	}
 	defer f.Close()
 	l.terminal.WriteHistory(f)


### PR DESCRIPTION

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number:  #162

#### Description:

- only if 0 arguments are provided, localhostl:9669 with root user will be used
- use exit or Fatal instead of Panic when any abnormal occurred

```
❯ ./nebula-console
Notice: Defaulting to localhost (127.0.0.1) with port 9669 using credentials (username: root, password: nebula).

Welcome!

(root@nebula) [(none)]>

❯ ./nebula-console -addr 10.1.1.168 -port 9669
Error: Invalid flags provided: the following required flags are missing or invalid: username
Tip: Use the --help option for guidance on correct flag usage.

❯ ./nebula-console -addr 10.1.1.168
Error: Invalid flags provided: the following required flags are missing or invalid: port, username
Tip: Use the --help option for guidance on correct flag usage.

```

Before, it's like this:

```
2024/03/15 08:29:13 Error: argument port is missed!
panic: Error: argument port is missed!

goroutine 1 [running]:
log.Panicf(0x7638b8, 0x1f, 0x0, 0x0, 0x0)
	/opt/hostedtoolcache/go/1.16.4/x64/src/log/log.go:361 +0xc5
main.validateFlags()
	/home/runner/work/nebula-console/nebula-console/main.go:467 +0x174
main.main()
	/home/runner/work/nebula-console/nebula-console/main.go:500 +0x10b
```
